### PR TITLE
Improved binary decoding performance and other minor fixes.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 # User-specific files
 *.suo
 *.user
+*.userosscache
 *.sln.docstates
 
 # Build results
@@ -35,6 +36,9 @@
 *.vspscc
 .builds
 *.dotCover
+
+# Visual Studio 2015 cache/options directory
+.vs/
 
 ## TODO: If you have NuGet Package Restore enabled, uncomment this
 #packages/

--- a/Codecs/Binary.cs
+++ b/Codecs/Binary.cs
@@ -350,7 +350,7 @@ namespace Datamodel.Codecs
                     if (defer_mode == DeferredMode.Automatic)
                     {
                         CodecUtilities.AddDeferredAttribute(elem, name, Reader.BaseStream.Position);
-                        SkipAttribte();
+                        SkipAttribute();
                     }
                     else
                     {
@@ -388,7 +388,7 @@ namespace Datamodel.Codecs
             }
         }
 
-        void SkipAttribte()
+        void SkipAttribute()
         {
             var types = IdToType(Reader.ReadByte());
 

--- a/Codecs/KeyValues2.cs
+++ b/Codecs/KeyValues2.cs
@@ -283,7 +283,7 @@ namespace Datamodel.Codecs
         void WriteElement(Element element)
         {
             if (TypeNames.ContainsValue(element.ClassName))
-                throw new CodecException(String.Format("Element {} uses reserved type name \"{1}\".", element.ID, element.ClassName));
+                throw new CodecException(String.Format("Element {0} uses reserved type name \"{1}\".", element.ID, element.ClassName));
             Writer.WriteTokens(element.ClassName);
             Writer.WriteLine("{");
             Writer.Indent++;


### PR DESCRIPTION
Performance boost from reflection changes:
- `Perf_Load_Binary5` runs around 40 milliseconds faster
- Loading bigger binary DMX data (around 50MB) ran 3 seconds faster (from 19 seconds to 16 seconds)

EDIT: Similar changes might be possible [here](https://github.com/Artfunkel/Datamodel.NET/blob/e4c0705ff5ac98e9dc62de0758f1edf67285325a/Codecs/Binary.cs#L553), since the `TypeToId` function calls `IsDatamodelArrayType` as well.