### PR TITLE
Read strings as raw when reading prefix

### DIFF
--- a/Codecs/Binary.cs
+++ b/Codecs/Binary.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -315,7 +315,7 @@ namespace Datamodel.Codecs
                     foreach (int attr_index in Enumerable.Range(0, Reader.ReadInt32()))
                     {
                         var name = ReadString_Raw();
-                        var value = DecodeAttribute(dm);
+                        var value = DecodeAttribute(dm, true);
                         if (prefix_elem == 0) // skip subsequent elements...are they considered "old versions"?
                             dm.PrefixAttributes[name] = value;
                     }
@@ -354,7 +354,7 @@ namespace Datamodel.Codecs
                     }
                     else
                     {
-                        elem.Add(name, DecodeAttribute(dm));
+                        elem.Add(name, DecodeAttribute(dm, false));
                     }
                 }
             }
@@ -366,15 +366,15 @@ namespace Datamodel.Codecs
         public object DeferredDecodeAttribute(Datamodel dm, long offset)
         {
             Reader.BaseStream.Seek(offset, SeekOrigin.Begin);
-            return DecodeAttribute(dm);
+            return DecodeAttribute(dm, false);
         }
 
-        object DecodeAttribute(Datamodel dm)
+        object DecodeAttribute(Datamodel dm, bool prefix)
         {
             var type = IdToType(Reader.ReadByte());
 
             if (!Datamodel.IsDatamodelArrayType(type))
-                return ReadValue(dm, type, EncodingVersion < 4);
+                return ReadValue(dm, type, EncodingVersion < 4 || prefix);
             else
             {
                 var count = Reader.ReadInt32();


### PR DESCRIPTION
Fix to binary format 9 reading that forces strings to be decoded as raw text rather than a StringDict reference (which throws a NullReferenceException). This seems to be an intentional decision on Valve's part to keep file reading linear, as the string dictionary comes after the prefix.